### PR TITLE
Package App for Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ Thumbs.db
 /app/index.js
 /app/env.json
 /app/**/*.map
+/app/transpile
+
+# build directories
+/Trace-*
 
 /dist
 

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
   },
   "homepage": "https://github.com/RPI-Void-Star/trace#readme",
   "dependencies": {
+    "electron-is-dev": "^0.1.2",
     "fs-jetpack": "^0.9.2"
   }
 }

--- a/setup/install.cmd
+++ b/setup/install.cmd
@@ -1,0 +1,1 @@
+pip install -r requirements.txt

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const electron = require('electron');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
+const isDev = require('electron-is-dev');
 
 let mainWindow = null;
 
@@ -40,7 +41,14 @@ electron.ipcMain.on('load-file', (event, arg) => {
 });
 
 electron.ipcMain.on('transpile-file', (event, arg) => {
-  const transpiler = spawn('python', ['transpile/main.py', arg.filename, arg.port]);
+  let path;
+  if (isDev) {
+    path = 'transpile/main.py';
+  } else {
+    path = 'resources/app/transpile/main.py';
+  }
+
+  const transpiler = spawn('python', [path, arg.filename, arg.port]);
   let errorBuffer = '';
   let outBuffer = '';
 
@@ -68,9 +76,15 @@ electron.ipcMain.on('transpile-file', (event, arg) => {
 
 let serialProcess;
 electron.ipcMain.on('open-serial', (event, arg) => {
-  let errorBuffer = '';
+  let path;
+  if (isDev) {
+    path = 'transpile/com_test.py';
+  } else {
+    path = 'resources/app/transpile/com_test.py';
+  }
 
-  serialProcess = spawn('python', ['transpile/com_test.py', arg.port]);
+  serialProcess = spawn('python', [path, arg.port]);
+  let errorBuffer = '';
 
   serialProcess.stdout.on('data', (data) => {
     console.log(`stdout: ${data}`);

--- a/tasks/build_app.js
+++ b/tasks/build_app.js
@@ -10,11 +10,12 @@ const utils = require('./utils');
 const srcDir = jetpack.cwd('./src');
 const destDir = jetpack.cwd('./app');
 
-gulp.task('bundle', () =>
+gulp.task('bundle', () => {
+  gulp.src('./transpile/**/*').pipe(gulp.dest('./app/transpile'));
   Promise.all([
     bundle(srcDir.path('index.js'), destDir.path('index.js')),
-  ])
-);
+  ]);
+});
 
 gulp.task('less', () =>
   gulp.src(srcDir.path('stylesheets/main.less'))


### PR DESCRIPTION
I made some slight modifications so that we can use electron-packager to bundle the app into .exe, .app, etc. The only requirement now is that python 3 is installed globally and the python dependencies are installed.